### PR TITLE
Add catalog-info.yaml for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1 # Do not touch
+kind: Component # Do not touch
+metadata:
+  annotations: 
+    github.com/project-slug: worldcoin/mini-apps-ui-kit # your github project slug for example worldcoin/infrastructure
+  tags: ["code-lang:typescript"] # Replace yourCodeLanguage. Also feel free to add more tags in the format of "key:value".
+  description: Your project description # Add your project description
+  links: # Feel free to add more links
+  - title: Linear # Do not touch
+    url: https://yourLinearProjectUrl # A link to your Linear project
+  - title: Documentation # Do not touch
+    url: https://yourProjectDocumentation # A link to your documentation
+  name: mini-apps-ui-kit # Should be the Github slug
+spec: 
+  lifecycle: production # Do not touch
+  owner: studios # Should be the exact name of a github team https://github.com/orgs/worldcoin/teams, https://github.com/orgs/worldcoin/teams/engineering/teams
+  type: service # Can be service, website, library, or a more specific self defined. https://backstage.io/docs/features/software-catalog/system-model/


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the worldcoin Backstage App software catalog.

After this pull request is merged, the component will become available in [development](https://backstage-dev.worldcoin.dev/catalog) and later in [production](https://backstage.worldcoin.dev/catalog) 

Feel free to make changes to the file. For more information, [read our instructions](https://www.notion.so/worldcoin/Service-Catalogue-15e8614bdf8c8008b801f54ec6809ed8).