### PR TITLE
Add contributing guidelines and version management section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,36 @@ pnpm preview:sb
 - `packages/@mini-apps-ui-kit-react`: React components library
 - `packages/@mini-apps-ui-kit-react/src/components`: React components, make sure every component has it's own index.ts file
 - `packages/@mini-apps-ui-kit-react/stories`: Storybook stories
+
+## Contributing
+
+We use [changesets](https://github.com/changesets/changesets) to manage our versioning and changelogs. To contribute to this repository, please follow these steps:
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/your-feature`)
+3. Make your changes
+4. Run `pnpm changeset` to create a changeset that describes your changes
+   - This will prompt you to:
+     - Select which packages you want to release
+     - Choose the type of version bump (major, minor, patch)
+     - Provide a summary of the changes
+5. Commit your changes (`git commit -m 'Add some feature'`)
+6. Push to the branch (`git push origin feature/your-feature`)
+7. Open a Pull Request
+
+Make sure to:
+- Follow the existing code style
+- Update documentation as needed
+- Add tests if applicable
+- Include a changeset with your changes
+
+## Version Management
+
+Version management is handled by the repository's CODEOWNERS. They are responsible for:
+
+- Reviewing and approving version bumps
+- Managing the release process
+- Ensuring changesets are properly created and maintained
+- Publishing new versions of the packages
+
+Only CODEOWNERS have the authority to merge version-related changes and execute releases.


### PR DESCRIPTION
This pull request adds contributing guidelines and a version management section to the README. The contributing guidelines provide instructions for contributing to the repository, including forking the repository, creating a feature branch, making changes, and opening a pull request. The version management section explains how versioning and changelogs are managed using changesets, and outlines the responsibilities of the CODEOWNERS in reviewing and approving version bumps, managing the release process, and publishing new versions of the packages.