### PR TITLE
Add long press functionality to NumberPad component

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ We use [changesets](https://github.com/changesets/changesets) to manage our vers
 7. Open a Pull Request
 
 Make sure to:
+
 - Follow the existing code style
 - Update documentation as needed
 - Add tests if applicable

--- a/packages/mini-apps-ui-kit-react/CHANGELOG.md
+++ b/packages/mini-apps-ui-kit-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @worldcoin/mini-apps-ui-kit-react
 
+## 0.0.4
+
+### Patch Changes
+
+- Added `onLongDeletePress` prop to `NumberPad` component to handle long press on the delete button.
+- Added `longPressOptions` prop to `NumberPad` component to customize long press behavior.
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/mini-apps-ui-kit-react/package.json
+++ b/packages/mini-apps-ui-kit-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldcoin/mini-apps-ui-kit-react",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -161,6 +161,7 @@
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.1",
+    "@uidotdev/usehooks": "^2.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "countries-list": "^3.1.1",

--- a/packages/mini-apps-ui-kit-react/src/components/NumberPad/NumberPad.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/NumberPad/NumberPad.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { LongPressOptions, useLongPress } from "@uidotdev/usehooks";
+
 import { Delete } from "./Delete";
 
 interface NumberPadProps {
@@ -15,6 +17,20 @@ interface NumberPadProps {
    * Callback fired when the value changes
    */
   onChange?: (value: string) => void;
+  /**
+   * Callback fired on long press of the delete button
+   */
+  onLongDeletePress?: () => void;
+  /**
+   * Options for the long press
+   * @type LongPressOptions
+   * @property { number } threshold - The time in milliseconds before the long press is triggered
+   * @property { (e: Event) => void } onStart - Callback fired when the long press starts
+   * @property { (e: Event) => void } onFinish - Callback fired when the long press finishes
+   * @property { (e: Event) => void } onCancel - Callback fired when the long press is cancelled
+   * @default { threshold: 1500 }
+   */
+  longPressOptions?: LongPressOptions;
 }
 
 const buttons = [
@@ -32,7 +48,15 @@ const buttons = [
   { value: "del", label: <Delete className="size-6" /> },
 ];
 
-export const NumberPad = ({ value = "", onChange, disabled = false }: NumberPadProps) => {
+export const NumberPad = ({
+  value = "",
+  onChange,
+  disabled = false,
+  onLongDeletePress = () => {},
+  longPressOptions = {
+    threshold: 1500,
+  },
+}: NumberPadProps) => {
   // Validate that value is a valid number or empty string
   if (value !== "" && isNaN(Number(value))) {
     console.error("NumberPad value must be a valid number or empty string");
@@ -55,6 +79,8 @@ export const NumberPad = ({ value = "", onChange, disabled = false }: NumberPadP
     }
   };
 
+  const longPressAttributes = useLongPress(onLongDeletePress, longPressOptions);
+
   return (
     <div className="grid grid-cols-3 grid-rows-4 gap-1 w-full">
       {buttons.map((button) => (
@@ -64,6 +90,7 @@ export const NumberPad = ({ value = "", onChange, disabled = false }: NumberPadP
           onClick={() => handleButtonClick(button.value)}
           disabled={disabled}
           className="h-12 min-w-28 flex items-center justify-center text-[1.625rem] font-semibold font-display rounded-md transition-colors duration-200 active:bg-gray-50 select-none disabled:text-gray-300 disabled:cursor-not-allowed disabled:active:bg-transparent"
+          {...(button.value === "del" ? longPressAttributes : {})}
         >
           {button.label || button.value}
         </button>

--- a/packages/mini-apps-ui-kit-react/stories/NumberPad.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/NumberPad.stories.tsx
@@ -65,3 +65,34 @@ export const Controlled: Story = {
     );
   },
 };
+
+export const ClearOnLongDeletePress: Story = {
+  args: {
+    value: "",
+    longPressOptions: {
+      threshold: 1500,
+    },
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+
+    const handleLongDeletePress = () => {
+      setValue("");
+    };
+
+    return (
+      <div className="flex flex-col gap-4 items-center w-[400px]">
+        <div className="font-display font-semibold flex items-center gap-2 h-[4.25rem]">
+          <span className="text-xl">$</span>
+          <span className="text-[3.5rem]">{value}</span>
+        </div>
+        <NumberPad
+          {...args}
+          value={value}
+          onChange={setValue}
+          onLongDeletePress={handleLongDeletePress}
+        />
+      </div>
+    );
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.1.1
         version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@uidotdev/usehooks':
+        specifier: ^2.4.1
+        version: 2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -778,7 +781,7 @@ packages:
   '@radix-ui/react-direction@1.1.0':
     resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
     peerDependencies:
-      '@types/react': 18.2.0
+      '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1523,6 +1526,13 @@ packages:
   '@typescript-eslint/visitor-keys@8.18.2':
     resolution: {integrity: sha512-zORcwn4C3trOWiCqFQP1x6G3xTRyZ1LYydnj51cRnJ6hxBlr/cKPckk+PKPUw/fXmvfKTcw7bwY3w9izgx5jZw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@uidotdev/usehooks@2.4.1':
+    resolution: {integrity: sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   '@ungap/structured-clone@1.2.1':
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
@@ -5646,6 +5656,11 @@ snapshots:
       '@typescript-eslint/types': 8.18.2
       eslint-visitor-keys: 4.2.0
 
+  '@uidotdev/usehooks@2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@ungap/structured-clone@1.2.1': {}
 
   '@vitejs/plugin-react@4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.6)(less@4.2.0)(terser@5.36.0)(yaml@2.6.1))':
@@ -6451,7 +6466,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -6473,7 +6488,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.2(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
This pull request enhances the `NumberPad` component by adding support for long press functionality on the delete button. It introduces two new props, `onLongDeletePress` and `longPressOptions`, to provide more control over the delete button's behavior.