### PR TITLE
Add client directive to SearchField

### DIFF
--- a/.changeset/good-birds-fold.md
+++ b/.changeset/good-birds-fold.md
@@ -1,0 +1,5 @@
+---
+"@worldcoin/mini-apps-ui-kit-react": patch
+---
+
+Add client directive to SearchField

--- a/packages/mini-apps-ui-kit-react/src/components/SearchField/SearchField.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/SearchField/SearchField.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createChangeEvent } from "@/lib/utils";
 import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 

--- a/packages/mini-apps-ui-kit-react/stories/Button.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Button.stories.tsx
@@ -8,6 +8,14 @@ import { Star } from "./helpers/icons/Star";
 const meta: Meta<typeof Button> = {
   title: "components/Button",
   component: Button,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A versatile button component that supports different variants, sizes, and states with optional icon support.",
+      },
+    },
+  },
   argTypes: {
     variant: {
       control: "radio",
@@ -53,6 +61,13 @@ export const Text: Story = {
     radius: "md",
     fullWidth: false,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "A basic button with text content only.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = await canvas.findByText("Button");
@@ -70,6 +85,14 @@ export const TextWithIcon: Story = {
     radius: "md",
     fullWidth: false,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A button that combines text and an icon, demonstrating how to use both elements together.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = await canvas.findByText("Button");
@@ -86,6 +109,13 @@ export const Icon: Story = {
     variant: "primary",
     size: "md",
     radius: "md",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A button that displays an icon only.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/packages/mini-apps-ui-kit-react/stories/Checkbox.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Checkbox.stories.tsx
@@ -7,6 +7,14 @@ import { Checkbox } from "../src/components/Checkbox";
 const meta: Meta<typeof Checkbox> = {
   title: "components/Checkbox",
   component: Checkbox,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A customizable checkbox component that supports checked, unchecked, and disabled states.",
+      },
+    },
+  },
 };
 
 export default meta;

--- a/packages/mini-apps-ui-kit-react/stories/Chip.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Chip.stories.tsx
@@ -8,6 +8,14 @@ import { Shield } from "./helpers/icons/Shield";
 const meta: Meta<ChipProps> = {
   title: "components/Chip",
   component: Chip,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A chip component that displays labels with optional icons and different variants including success, warning, error, and important states.",
+      },
+    },
+  },
   argTypes: {
     icon: iconControl,
   },
@@ -21,6 +29,13 @@ export const Default: Story = {
   args: {
     label: "Default",
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "The default chip variant without any icon or special styling.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const chip = await canvas.findByText("Default");
@@ -33,6 +48,13 @@ export const DefaultWithIcon: Story = {
   args: {
     label: "Default with icon",
     icon: <Shield />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A chip that includes an icon alongside the label text.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -49,6 +71,13 @@ export const SuccessWithIcon: Story = {
     label: "Success with icon",
     variant: "success",
     icon: <Shield variant="success" />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A success-themed chip with green styling and a matching icon.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -67,6 +96,13 @@ export const WarningWithIcon: Story = {
     variant: "warning",
     icon: <Shield variant="warning" />,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "A warning-themed chip with amber styling and a matching icon.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const chip = await canvas.findByText("Warning with icon");
@@ -83,6 +119,13 @@ export const ErrorWithIcon: Story = {
     label: "Error with icon",
     variant: "error",
     icon: <Shield variant="error" />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "An error-themed chip with red styling and a matching icon.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -101,6 +144,13 @@ export const ImportantWithIcon: Story = {
     variant: "important",
     icon: <Shield variant="important" />,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "An important-themed chip with blue styling and a matching icon.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const chip = await canvas.findByText("Important with icon");
@@ -118,6 +168,14 @@ export const DifferentColors: Story = {
     variant: "important",
     className: "bg-success-100 text-primary-pink",
     icon: <Shield variant="important" color="#9D50FF" />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A chip demonstrating custom color combinations using className and color props.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/packages/mini-apps-ui-kit-react/stories/Form.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Form.stories.tsx
@@ -11,6 +11,14 @@ type FormStoryProps = FormProps & {
 const meta: Meta<FormStoryProps> = {
   title: "components/Form",
   component: Form.Root,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A form component that provides form validation and submission handling functionality.",
+      },
+    },
+  },
 };
 
 export default meta;

--- a/packages/mini-apps-ui-kit-react/stories/Input.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Input.stories.tsx
@@ -9,6 +9,14 @@ import { Switch } from "./helpers/icons/Switch";
 const meta: Meta<InputProps> = {
   title: "components/Input",
   component: Input,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A customizable text input component that supports adornments and various states.",
+      },
+    },
+  },
   argTypes: {
     startAdornment: iconControl,
     endAdornment: iconControl,
@@ -43,6 +51,13 @@ export const Text: Story = {
   args: {
     placeholder: "Enter your name",
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Basic text input with placeholder text.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = await canvas.findByPlaceholderText("Enter your name");
@@ -55,6 +70,13 @@ export const Disabled: Story = {
   args: {
     placeholder: "Enter your name",
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Input in a disabled state where user interaction is prevented.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -70,6 +92,13 @@ export const StartCustomSizeIcon: Story = {
     startAdornment: <CountryCode />,
     startAdornmentWidth: 4.5,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Input with a custom-sized icon at the start position.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const icon = await canvas.findByTestId("country-code-icon");
@@ -83,6 +112,13 @@ export const EndCustomSizeIcon: Story = {
     placeholder: "Enter your number",
     endAdornment: <Switch />,
     endAdornmentWidth: 2,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Input with a custom-sized icon at the end position.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/packages/mini-apps-ui-kit-react/stories/PhoneField.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/PhoneField.stories.tsx
@@ -11,6 +11,14 @@ import { iconControl } from "./helpers/icon-control";
 const meta: Meta<typeof PhoneField> = {
   title: "components/PhoneField",
   component: PhoneField,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A phone number input field with country code selection and formatting support.",
+      },
+    },
+  },
   argTypes: {
     endAdornment: iconControl,
     disableDialCodePrefill: {
@@ -38,6 +46,13 @@ export const Default: Story = {
     const [value, setValue] = useState("");
 
     return <PhoneField {...args} value={value} onChange={setValue} />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "The default phone field with country code selector as a dropdown.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -67,6 +82,14 @@ export const CountrySelectorAsDrawer: Story = {
     return (
       <PhoneField {...args} value={value} onChange={setValue} countrySelectorMode="drawer" />
     );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Phone field with country selector displayed as a bottom drawer, suitable for mobile interfaces.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -122,6 +145,13 @@ export const AllowedCountryCodesProvided: Story = {
 
     return <PhoneField {...args} value={value} onChange={setValue} />;
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Phone field with a restricted list of available country codes.",
+      },
+    },
+  },
   args: {
     countrySelectorMode: "drawer",
     disableDialCodePrefill: false,
@@ -170,6 +200,14 @@ export const DialCodeInInputOnInitialization: Story = {
 
     return <PhoneField {...args} value={value} onChange={setValue} />;
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Phone field that automatically includes the country dial code in the input field on initialization.",
+      },
+    },
+  },
   args: {
     disableDialCodePrefill: false,
     defaultCountryCode: "DE",
@@ -200,6 +238,14 @@ export const WithoutDialCodeWithinButton: Story = {
     const [value, setValue] = useState("");
 
     return <PhoneField {...args} value={value} onChange={setValue} />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Phone field with hidden dial code in the country selector button for a cleaner look.",
+      },
+    },
   },
   args: {
     hideDialCode: true,
@@ -234,6 +280,13 @@ export const WithErrorLabel: Story = {
       </Form.Root>
     );
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Phone field in an error state with error message display.",
+      },
+    },
+  },
   args: {
     error: true,
   },
@@ -256,6 +309,13 @@ export const Disabled: Story = {
 
     return <PhoneField {...args} value={value} onChange={setValue} />;
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Phone field in a disabled state where user interaction is prevented.",
+      },
+    },
+  },
   args: {
     disabled: true,
   },
@@ -276,6 +336,14 @@ export const ShowValidStateWhenMin12Digits: Story = {
     const isValid = value.length >= 12;
 
     return <PhoneField {...args} value={value} onChange={setValue} isValid={isValid} />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Phone field that shows a success state when the input reaches a minimum length of 12 digits.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -299,8 +367,15 @@ export const ShowValidStateWhenMin12Digits: Story = {
 export const CustomDefaultCountry: Story = {
   render: (args) => {
     const [value, setValue] = useState("");
-
     return <PhoneField {...args} value={value} onChange={setValue} />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Phone field initialized with a specific country code and the ability to change it.",
+      },
+    },
   },
   args: {
     defaultCountryCode: "PL",

--- a/packages/mini-apps-ui-kit-react/stories/Pill.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Pill.stories.tsx
@@ -7,6 +7,12 @@ const meta: Meta<typeof Pill> = {
   component: Pill,
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A pill-shaped component that can be used as a toggle or label with a rounded appearance.",
+      },
+    },
   },
   tags: ["autodocs"],
   argTypes: {

--- a/packages/mini-apps-ui-kit-react/stories/RadioGroup.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/RadioGroup.stories.tsx
@@ -8,6 +8,14 @@ import { cn } from "../src/lib/utils";
 const meta: Meta<typeof RadioGroup> = {
   title: "components/RadioGroup",
   component: RadioGroup,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A radio group component that allows users to select a single option from a list of choices.",
+      },
+    },
+  },
   subcomponents: {
     RadioGroupItem: RadioGroupItem as React.ComponentType<unknown>,
   },
@@ -45,6 +53,13 @@ export const Default: Story = {
       ))}
     </RadioGroup>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Basic radio group with vertical orientation and unlabeled options.",
+      },
+    },
+  },
   args: {
     defaultValue: "option1",
     orientation: "vertical",
@@ -86,6 +101,13 @@ export const WithLabels: Story = {
       })}
     </RadioGroup>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Radio group with labeled options for better accessibility and user experience.",
+      },
+    },
+  },
   args: {
     defaultValue: "option2",
     orientation: "vertical",
@@ -133,6 +155,13 @@ export const DisabledItems: Story = {
       })}
     </RadioGroup>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Radio group demonstrating disabled state for specific options.",
+      },
+    },
+  },
   args: {
     defaultValue: "option1",
     orientation: "vertical",
@@ -167,6 +196,13 @@ export const Controlled: Story = {
         ))}
       </RadioGroup>
     );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Radio group as a controlled component with external state management.",
+      },
+    },
   },
   args: {
     defaultValue: "option3",
@@ -208,6 +244,14 @@ export const OneControlledRadioElement: Story = {
         <RadioGroupItem value={option1} />
       </RadioGroup>
     );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Radio group with a single controlled radio element that can be toggled on and off.",
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/packages/mini-apps-ui-kit-react/stories/Select.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Select.stories.tsx
@@ -9,6 +9,14 @@ import { Select, SelectOption, SelectProps } from "../src/components/Select";
 const meta: Meta<typeof Select> = {
   title: "components/Select",
   component: Select,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A select component that provides a dropdown list of options with support for default values, disabled state, and error handling.",
+      },
+    },
+  },
   argTypes: {
     value: {
       control: false,
@@ -40,6 +48,13 @@ export const Default: Story = {
 
     return <Select {...args} value={selectedValue} onChange={setSelectedValue} />;
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Basic select component with placeholder and dropdown options.",
+      },
+    },
+  },
   args: {
     options,
     placeholder: "Value",
@@ -60,6 +75,13 @@ export const Default: Story = {
 export const WithDefaultValue: Story = {
   render: (args) => {
     return <Select {...args} />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Select component initialized with a pre-selected value.",
+      },
+    },
   },
   args: {
     options,
@@ -120,6 +142,13 @@ export const Disabled: Story = {
   render: (args) => {
     return <Select {...args} />;
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Select component in a disabled state where user interaction is prevented.",
+      },
+    },
+  },
   args: {
     options,
     placeholder: "Value",
@@ -149,6 +178,13 @@ export const WithErrorLabel: Story = {
       </Form.Root>
     );
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Select component in an error state with error message display.",
+      },
+    },
+  },
   args: {
     options,
     placeholder: "Value",
@@ -172,6 +208,13 @@ export const WithDefaultOpen: Story = {
     const [selectedValue, setSelectedValue] = useState<string | undefined>();
 
     return <Select {...args} value={selectedValue} onChange={setSelectedValue} />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Select component that opens its dropdown automatically on mount.",
+      },
+    },
   },
   args: {
     options,
@@ -197,6 +240,13 @@ export const LongList: Story = {
     const [selectedValue, setSelectedValue] = useState<string | undefined>();
 
     return <Select {...args} value={selectedValue} onChange={setSelectedValue} />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Select component with a scrollable list of many options.",
+      },
+    },
   },
   args: {
     options: longListOptions,
@@ -247,6 +297,13 @@ export const ControlledOpen: Story = {
         />
       </>
     );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Select component with externally controlled open state via a toggle button.",
+      },
+    },
   },
   args: {
     options,

--- a/packages/mini-apps-ui-kit-react/stories/Switch.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Switch.stories.tsx
@@ -7,6 +7,14 @@ import { Switch, SwitchProps } from "../src/components/Switch";
 const meta: Meta<SwitchProps> = {
   title: "components/Switch",
   component: Switch,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A toggle switch component that provides a visual way to turn an option on or off.",
+      },
+    },
+  },
 };
 
 export default meta;
@@ -26,6 +34,14 @@ const Template: StoryFn<SwitchProps> = (args) => {
 
 export const Unchecked: Story = Template.bind({});
 
+Unchecked.parameters = {
+  docs: {
+    description: {
+      story: "Switch component in its default unchecked state.",
+    },
+  },
+};
+
 Unchecked.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   const switchElement = await canvas.findByRole("switch");
@@ -39,6 +55,14 @@ Unchecked.play = async ({ canvasElement }) => {
 };
 
 export const Checked: Story = Template.bind({});
+
+Checked.parameters = {
+  docs: {
+    description: {
+      story: "Switch component in its checked state.",
+    },
+  },
+};
 
 Checked.args = {
   checked: true,
@@ -59,6 +83,14 @@ Checked.play = async ({ canvasElement }) => {
 
 export const Disabled: Story = Template.bind({});
 
+Disabled.parameters = {
+  docs: {
+    description: {
+      story: "Switch component in a disabled state where user interaction is prevented.",
+    },
+  },
+};
+
 Disabled.args = {
   disabled: true,
 };
@@ -77,6 +109,14 @@ Disabled.play = async ({ canvasElement }) => {
 };
 
 export const ToggleSwitchTesting: Story = Template.bind({});
+
+ToggleSwitchTesting.parameters = {
+  docs: {
+    description: {
+      story: "Interactive demonstration of switch toggling behavior.",
+    },
+  },
+};
 
 ToggleSwitchTesting.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);

--- a/packages/mini-apps-ui-kit-react/stories/Typography.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Typography.stories.tsx
@@ -5,6 +5,14 @@ import { Typography } from "../src/components/Typography";
 const meta: Meta<typeof Typography> = {
   title: "components/Typography",
   component: Typography,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A versatile typography component that supports various text styles including headings, body text, numbers, and monospace with different size levels.",
+      },
+    },
+  },
   argTypes: {
     as: {
       table: {


### PR DESCRIPTION
Add the client directive to the SearchField component to enable Apollo Client support for the component.

docs: Add component descriptions to stories