### PR TITLE
Add PasswordField component with show/hide password functionality

### DIFF
--- a/packages/mini-apps-ui-kit-react/src/components/Icons/Eye.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/Icons/Eye.tsx
@@ -1,0 +1,36 @@
+import { cn } from "../../lib/utils";
+
+interface EyeProps {
+  /**
+   * Additional CSS classes to apply to the Eye icon
+   */
+  className?: string;
+}
+
+export function Eye({ className }: EyeProps) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("size-6", className)}
+    >
+      <path
+        d="M3 13C6.6 5 17.4 5 21 13"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12 17C10.3431 17 9 15.6569 9 14C9 12.3431 10.3431 11 12 11C13.6569 11 15 12.3431 15 14C15 15.6569 13.6569 17 12 17Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/packages/mini-apps-ui-kit-react/src/components/PasswordField/PasswordField.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/PasswordField/PasswordField.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { forwardRef, useState } from "react";
+
+import { Eye } from "../Icons/Eye";
+import { Input, InputProps } from "../Input";
+
+export interface PasswordFieldProps
+  extends Omit<InputProps, "startAdornment" | "startAdornmentWidth"> {
+  /**
+   * If true, the input will display in an error state with error styling
+   */
+  error?: boolean;
+  /**
+   * If true, the input will display in a valid state with success styling
+   */
+  isValid?: boolean;
+}
+
+export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
+  (
+    {
+      isValid,
+      disabled,
+      type = "password",
+      autoComplete = "current-password",
+      spellCheck = "false",
+      inputMode = "text",
+      autoCapitalize = "off",
+      autoCorrect = "off",
+      endAdornment: endAdornmentProp,
+      endAdornmentWidth: endAdornmentWidthProp,
+      ...props
+    },
+    ref,
+  ) => {
+    const [showPassword, setShowPassword] = useState(false);
+    return (
+      <Input
+        {...props}
+        ref={ref}
+        isValid={isValid}
+        disabled={disabled}
+        endAdornmentWidth={2.4}
+        endAdornment={
+          <button type="button" onClick={() => setShowPassword(!showPassword)}>
+            <Eye />
+          </button>
+        }
+        type={showPassword ? "text" : "password"}
+        autoComplete={autoComplete}
+        spellCheck={spellCheck}
+        inputMode={inputMode}
+        autoCapitalize={autoCapitalize}
+        autoCorrect={autoCorrect}
+      />
+    );
+  },
+);
+
+PasswordField.displayName = "PasswordField";
+
+export default PasswordField;

--- a/packages/mini-apps-ui-kit-react/src/components/PasswordField/index.ts
+++ b/packages/mini-apps-ui-kit-react/src/components/PasswordField/index.ts
@@ -1,0 +1,1 @@
+export * from "./PasswordField";

--- a/packages/mini-apps-ui-kit-react/stories/PasswordField.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/PasswordField.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PasswordField } from "../src/components/PasswordField/PasswordField";
+
+const meta: Meta<typeof PasswordField> = {
+  title: "Components/PasswordField",
+  component: PasswordField,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: "A password input component with a toggle to show/hide the password.",
+      },
+    },
+  },
+  args: {
+    placeholder: "Enter password",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-80 flex justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof PasswordField>;
+
+export const Default: Story = {
+  args: {},
+};


### PR DESCRIPTION
Introduce a new PasswordField component that allows users to toggle password visibility. Include an Eye icon for the toggle and add Storybook stories to demonstrate usage and styling.