### PR TITLE
Fix Drawer stories

### DIFF
--- a/packages/mini-apps-ui-kit-react/src/components/Drawer/Drawer.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/Drawer/Drawer.tsx
@@ -78,11 +78,12 @@ const DrawerContent = React.forwardRef<
 
       <DrawerPrimitive.Content
         ref={ref}
+        {...props}
         className={cn(
           "fixed inset-x-0 bottom-0 z-50 mt-24 bg-gray-0 outline-none p-8",
           fullPage ? "h-screen rounded-none" : "h-auto rounded-t-2xl",
+          props.className,
         )}
-        {...props}
       />
     </DrawerPrimitive.Portal>
   );

--- a/packages/mini-apps-ui-kit-react/stories/Drawer.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Drawer.stories.tsx
@@ -39,7 +39,7 @@ export const Default: StoryObj<typeof Drawer> = {
           Open
         </Button>
       </DrawerTrigger>
-      <DrawerContent className="flex flex-col items-center pb-4">
+      <DrawerContent>
         <DrawerHeader>
           <DrawerTitle>Drawer title</DrawerTitle>
         </DrawerHeader>


### PR DESCRIPTION
Allow additional props to be passed to the Drawer component and remove the default className in stories to improve flexibility in usage.