### PR TITLE
Add ToggleGroup component to UI kit

### DIFF
--- a/packages/mini-apps-ui-kit-react/package.json
+++ b/packages/mini-apps-ui-kit-react/package.json
@@ -129,6 +129,14 @@
       "types": "./dist/components/Marble/index.d.ts",
       "default": "./dist/components/Marble/index.js"
     },
+    "./ToggleGroup": {
+      "types": "./dist/components/ToggleGroup/index.d.ts",
+      "default": "./dist/components/ToggleGroup/index.js"
+    },
+    "./ToggleGroupItem": {
+      "types": "./dist/components/ToggleGroup/index.d.ts",
+      "default": "./dist/components/ToggleGroup/index.js"
+    },
     "./tailwind": {
       "types": "./dist/tailwind/index.d.ts",
       "default": "./dist/tailwind/index.js"
@@ -200,6 +208,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.1",
     "@radix-ui/react-toast": "^1.2.6",
+    "@radix-ui/react-toggle-group": "^1.1.2",
     "@uidotdev/usehooks": "^2.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/mini-apps-ui-kit-react/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/ToggleGroup/ToggleGroup.tsx
@@ -1,0 +1,37 @@
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+import { typographyVariants } from "../Typography";
+import { ToggleGroupItemProps, ToggleGroupRootProps } from "./types";
+
+const ToggleGroupRoot = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  ToggleGroupRootProps
+>(({ ...props }, ref) => (
+  <ToggleGroupPrimitive.Root ref={ref} className={cn("inline-flex gap-5")} {...props} />
+));
+ToggleGroupRoot.displayName = "ToggleGroup";
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  ToggleGroupItemProps
+>(({ className, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      typographyVariants({ variant: "subtitle", level: 4 }),
+      "size-8 rounded-full transition-all text-gray-400 bg-gray-0 outline-none",
+      "hover:bg-gray-50",
+      "data-[state=on]:bg-gray-100 data-[state=on]:text-gray-900",
+      "disabled:pointer-events-none disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </ToggleGroupPrimitive.Item>
+));
+ToggleGroupItem.displayName = "ToggleGroupItem";
+
+export { ToggleGroupRoot, ToggleGroupItem };

--- a/packages/mini-apps-ui-kit-react/src/components/ToggleGroup/index.ts
+++ b/packages/mini-apps-ui-kit-react/src/components/ToggleGroup/index.ts
@@ -1,0 +1,1 @@
+export { ToggleGroupRoot, ToggleGroupItem } from "./ToggleGroup";

--- a/packages/mini-apps-ui-kit-react/src/components/ToggleGroup/types.ts
+++ b/packages/mini-apps-ui-kit-react/src/components/ToggleGroup/types.ts
@@ -1,0 +1,115 @@
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import * as React from "react";
+
+/**
+ * Props for the ToggleGroupItem component
+ */
+export interface ToggleGroupItemProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>, "asChild"> {
+  /**
+   * Whether this item should be rendered as a child of another component
+   * @default false
+   */
+  asChild?: boolean;
+
+  /**
+   * The value of the toggle group item
+   */
+  value: string;
+
+  /**
+   * When true, prevents the user from interacting with the toggle group item
+   */
+  disabled?: boolean;
+}
+/**
+ * Props for single selection mode
+ */
+interface SingleToggleGroupProps {
+  /**
+   * The type of selection that should be used
+   */
+  type: "single";
+
+  /**
+   * The value of the toggle group when initially rendered
+   * @default undefined
+   */
+  defaultValue?: string;
+
+  /**
+   * The controlled value of the toggle group
+   * @default undefined
+   */
+  value?: string;
+
+  /**
+   * Event handler called when the value changes
+   */
+  onValueChange?: (value: string) => void;
+}
+
+/**
+ * Props for multiple selection mode
+ */
+interface MultipleToggleGroupProps {
+  /**
+   * The type of selection that should be used
+   */
+  type: "multiple";
+
+  /**
+   * The value of the toggle group when initially rendered
+   * @default undefined
+   */
+  defaultValue?: string[];
+
+  /**
+   * The controlled value of the toggle group
+   * @default undefined
+   */
+  value?: string[];
+
+  /**
+   * Event handler called when the value changes
+   */
+  onValueChange?: (value: string[]) => void;
+}
+
+/**
+ * Props for the ToggleGroupRoot component
+ */
+export type ToggleGroupRootProps = (SingleToggleGroupProps | MultipleToggleGroupProps) & {
+  /**
+   * Whether this component should be rendered as a child of another component
+   * @default false
+   */
+  asChild?: boolean;
+
+  /**
+   * When true, prevents the user from interacting with the toggle group
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * When true and rovingFocus is true, keyboard navigation will loop from last item to first, and vice versa.
+   * @default true
+   */
+  loop?: boolean;
+
+  /**
+   * When false, navigating through the items using arrow keys will be disabled.
+   * @default false
+   */
+  rovingFocus?: boolean;
+
+  /**
+   * The reading direction of the toggle group. If omitted, inherits globally from DirectionProvider or assumes LTR (left-to-right) reading mode.
+   * @default undefined
+   */
+  dir?: "ltr" | "rtl";
+  /**
+   * The children of the toggle group
+   */
+  children?: React.ReactNode;
+};

--- a/packages/mini-apps-ui-kit-react/src/index.ts
+++ b/packages/mini-apps-ui-kit-react/src/index.ts
@@ -27,4 +27,6 @@ export * from "./components/AlertDialog";
 export * from "./components/BottomBar";
 export * from "./components/Marble";
 export * from "./components/TopBar";
+export * from "./components/ToggleGroup";
+
 export { default as uiKitTailwindPlugin } from "./tailwind";

--- a/packages/mini-apps-ui-kit-react/stories/ToggleGroup.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/ToggleGroup.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ToggleGroupItem, ToggleGroupRoot } from "../src/components/ToggleGroup/ToggleGroup";
+
+const meta = {
+  title: "Components/ToggleGroup",
+  component: ToggleGroupRoot,
+  subcomponents: { ToggleGroupItem },
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A toggle group component that allows users to select one or multiple options.",
+      },
+    },
+  },
+  argTypes: {
+    type: {
+      control: "radio",
+      options: ["single", "multiple"],
+      description: "The type of selection that should be used",
+    },
+    defaultValue: {
+      description: "The value of the toggle group when initially rendered",
+    },
+    value: {
+      description: "The controlled value of the toggle group",
+    },
+    onValueChange: {
+      description: "Event handler called when the value changes",
+    },
+    disabled: {
+      control: "boolean",
+      description: "When true, prevents the user from interacting with the toggle group",
+    },
+    loop: {
+      control: "boolean",
+      description:
+        "When true, keyboard navigation will loop from last item to first, and vice versa",
+    },
+    rovingFocus: {
+      control: "boolean",
+      description: "When true, the group will get focus on mount",
+    },
+    dir: {
+      control: "radio",
+      options: ["ltr", "rtl"],
+      description: "The reading direction of the toggle group",
+    },
+    asChild: {
+      control: "boolean",
+      description: "Whether this component should be rendered as a child of another component",
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ToggleGroupRoot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    type: "single",
+    defaultValue: "1d",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A single-select toggle group where only one option can be selected at a time.",
+      },
+    },
+  },
+  render: () => (
+    <ToggleGroupRoot type="single" defaultValue="1d">
+      <ToggleGroupItem value="1d">1D</ToggleGroupItem>
+      <ToggleGroupItem value="1w">1W</ToggleGroupItem>
+      <ToggleGroupItem value="1m">1M</ToggleGroupItem>
+      <ToggleGroupItem value="1y">1Y</ToggleGroupItem>
+    </ToggleGroupRoot>
+  ),
+};
+
+export const Multiple: Story = {
+  args: {
+    type: "multiple",
+    defaultValue: ["1d"],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A multi-select toggle group where multiple options can be selected simultaneously.",
+      },
+    },
+  },
+  render: () => (
+    <ToggleGroupRoot type="multiple" defaultValue={["1d"]}>
+      <ToggleGroupItem value="1d">1D</ToggleGroupItem>
+      <ToggleGroupItem value="1w">1W</ToggleGroupItem>
+      <ToggleGroupItem value="1m">1M</ToggleGroupItem>
+      <ToggleGroupItem value="1y">1Y</ToggleGroupItem>
+    </ToggleGroupRoot>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    type: "single",
+    defaultValue: "1d",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A toggle group with a disabled option that cannot be selected.",
+      },
+    },
+  },
+  render: () => (
+    <ToggleGroupRoot type="single" defaultValue="1d">
+      <ToggleGroupItem value="1d">1D</ToggleGroupItem>
+      <ToggleGroupItem value="1w" disabled>
+        1W
+      </ToggleGroupItem>
+      <ToggleGroupItem value="1m">1M</ToggleGroupItem>
+      <ToggleGroupItem value="1y">1Y</ToggleGroupItem>
+    </ToggleGroupRoot>
+  ),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@radix-ui/react-toast':
         specifier: ^1.2.6
         version: 1.2.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -803,7 +806,7 @@ packages:
   '@radix-ui/react-direction@1.1.0':
     resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 18.2.0
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1009,6 +1012,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.2':
+    resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.1.4':
     resolution: {integrity: sha512-pOkb2u8KgO47j/h7AylCj7dJsm69BXcjkrvTqMptFqsE2i0p8lHkfgneXKjAgPzBMivnoMyt8o4KiV4wYzDdyQ==}
     peerDependencies:
@@ -1055,6 +1071,32 @@ packages:
 
   '@radix-ui/react-toast@1.2.6':
     resolution: {integrity: sha512-gN4dpuIVKEgpLn1z5FhzT9mYRUitbfZq9XqN/7kkBMUgFTzTG8x/KszWJugJXHcwxckY8xcKDZPz7kG3o6DsUA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.2':
+    resolution: {integrity: sha512-JBm6s6aVG/nwuY5eadhU2zDi/IwYS0sDM5ZWb4nymv/hn3hZdkw+gENn0LP4iY1yCd7+bgJaCwueMYJIU3vk4A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.2':
+    resolution: {integrity: sha512-lntKchNWx3aCHuWKiDY+8WudiegQvBpDRAYL8dKLRvKEH8VOpl0XX6SSU/bUBqIRJbcTy4+MW06Wv8vgp10rzQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5091,6 +5133,23 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
   '@radix-ui/react-select@2.1.4(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/number': 1.1.0
@@ -5163,6 +5222,32 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@radix-ui/react-toggle-group@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@radix-ui/react-toggle@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION
Introduce ToggleGroup and ToggleGroupItem components for single and multiple selection options, along with TypeScript types and Storybook stories for demonstration. Update package dependencies accordingly.