### PR TITLE
Refactor Delete component and enhance NumberPad input validation

### DIFF
--- a/packages/mini-apps-ui-kit-react/src/components/NumberPad/Delete.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/NumberPad/Delete.tsx
@@ -1,11 +1,4 @@
-interface DeleteProps {
-  /**
-   * Additional CSS classes to apply to the Delete icon
-   */
-  className?: string;
-}
-
-export function Delete({ className }: DeleteProps) {
+export function Delete(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       width="24"
@@ -13,14 +6,13 @@ export function Delete({ className }: DeleteProps) {
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      data-testid="delete-icon"
+      {...props}
     >
       <path
-        d="M17 9L14 12M14 12L11 15M14 12L11 9M14 12L17 15M3.52405 15.4403L7.34938 18.8689C8.16293 19.5981 9.2072 20 10.2882 20H17.5371C20.0019 20 22 17.9533 22 15.4286V8.57143C22 6.0467 20.0019 4 17.5371 4H10.2882C9.2072 4 8.16293 4.40191 7.34939 5.13108L3.52406 8.55965C1.49198 10.381 1.49198 13.619 3.52405 15.4403Z"
+        d="M15 6L9 12L15 18"
         stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
+        strokeWidth="2.5"
+        strokeLinecap="square"
       />
     </svg>
   );

--- a/packages/mini-apps-ui-kit-react/src/components/NumberPad/NumberPad.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/NumberPad/NumberPad.tsx
@@ -74,9 +74,9 @@ export const NumberPad = ({
       // Don't add another decimal point if one already exists
       return;
     } else {
-      // Validate that the new value would still be a valid number
       const newValue = value + buttonValue;
-      if (!isNaN(Number(newValue))) {
+      // Allow trailing decimal point for partial number input
+      if (buttonValue === "." || !isNaN(Number(newValue))) {
         onChange(newValue);
       }
     }

--- a/packages/mini-apps-ui-kit-react/src/components/NumberPad/NumberPad.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/NumberPad/NumberPad.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import { LongPressOptions, useLongPress } from "@uidotdev/usehooks";
 
+import { inputVariants } from "../Input";
+import { typographyVariants } from "../Typography";
 import { Delete } from "./Delete";
 
 interface NumberPadProps {
@@ -89,7 +92,11 @@ export const NumberPad = ({
           key={button.value}
           onClick={() => handleButtonClick(button.value)}
           disabled={disabled}
-          className="h-12 min-w-28 flex items-center justify-center text-[1.625rem] font-semibold font-display rounded-md transition-colors duration-200 active:bg-gray-50 select-none disabled:text-gray-300 disabled:cursor-not-allowed disabled:active:bg-transparent"
+          className={cn(
+            typographyVariants({ variant: "heading", level: 3 }),
+            "h-12 min-w-28 flex items-center justify-center  rounded-md transition-colors duration-200",
+            "active:bg-gray-50 select-none disabled:text-gray-300 disabled:cursor-not-allowed disabled:active:bg-transparent",
+          )}
           {...(button.value === "del" ? longPressAttributes : {})}
         >
           {button.label || button.value}


### PR DESCRIPTION
Simplify the Delete component by allowing direct SVG props and improve its icon styling. Update NumberPad to permit trailing decimal points in input validation, enhancing user experience.

Fixes STU-1132