### PR TITLE
Allow tailwind version 4

### DIFF
--- a/packages/mini-apps-ui-kit-react/package.json
+++ b/packages/mini-apps-ui-kit-react/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19",
-    "tailwindcss": "^3"
+    "tailwindcss": "^3 || ^4"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {


### PR DESCRIPTION
Tailwind version 4 is not allowed with this using npm as a peer dependency. This works fine if you use PNPM since it automatically does the conflict resolution
<img width="796" alt="Screenshot 2025-04-17 at 4 44 49 PM" src="https://github.com/user-attachments/assets/aa6e3fde-724b-4677-9db8-c8983337b3b6" />
