### PR TITLE
Execute haptics before callback in Button

### DIFF
--- a/packages/mini-apps-ui-kit-react/CHANGELOG.md
+++ b/packages/mini-apps-ui-kit-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @worldcoin/mini-apps-ui-kit-react
 
+## 1.2.1
+
+### Patch Changes
+
+- Execute haptics before callback in Button.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/mini-apps-ui-kit-react/package.json
+++ b/packages/mini-apps-ui-kit-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldcoin/mini-apps-ui-kit-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/mini-apps-ui-kit-react/src/lib/haptics.ts
+++ b/packages/mini-apps-ui-kit-react/src/lib/haptics.ts
@@ -58,21 +58,27 @@ export function withHaptics<T extends (...args: any[]) => any>(
   hapticFn: () => void = haptics.selection,
 ): T {
   return ((...args: Parameters<T>) => {
-    if (!fn) {
+    try {
       hapticFn();
-      return undefined;
+    } catch (error) {
+      console.warn('Haptic feedback failed:', error);
+    }
+    
+    if (!fn) {
+      return undefined as ReturnType<T>;
     }
 
     const result = fn(...args);
 
     // Handle async functions
     if (result instanceof Promise) {
-      return result.finally(() => hapticFn());
+      return result.catch((error) => {
+        console.error('Function failed:', error);
+        throw error;
+      }) as ReturnType<T>;
     }
 
-    // Handle sync functions
-    hapticFn();
-    return result;
+    return result as ReturnType<T>;
   }) as T;
 }
 


### PR DESCRIPTION
Ensure haptic feedback is triggered before executing the callback in the Button component, improving user experience.