### PR TITLE
Remove autocomplete from PhoneField

### DIFF
--- a/packages/mini-apps-ui-kit-react/CHANGELOG.md
+++ b/packages/mini-apps-ui-kit-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @worldcoin/mini-apps-ui-kit-react
 
+## 1.2.4
+
+### Patch Changes
+
+- Remove default autocomplete value in the PhoneField. The dependency underneath `react-international-phone` does not support autocomplete.
+
 ## 1.2.3
 
 ### Patch Changes

--- a/packages/mini-apps-ui-kit-react/package.json
+++ b/packages/mini-apps-ui-kit-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldcoin/mini-apps-ui-kit-react",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/mini-apps-ui-kit-react/src/components/PhoneField/PhoneField.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/PhoneField/PhoneField.tsx
@@ -76,7 +76,6 @@ const PhoneField = forwardRef<HTMLDivElement, PhoneFieldProps>(
       endAdornment,
       type = "tel",
       inputMode = "tel",
-      autoComplete = "tel",
       autoCapitalize = "off",
       autoCorrect = "off",
       ...props
@@ -124,7 +123,6 @@ const PhoneField = forwardRef<HTMLDivElement, PhoneFieldProps>(
         ref={inputRef}
         type={type}
         inputMode={inputMode}
-        autoComplete={autoComplete}
         autoCapitalize={autoCapitalize}
         autoCorrect={autoCorrect}
         value={inputValue}


### PR DESCRIPTION
Remove the default value to `autocomplete=tel` in the PhoneField. The dependency `react-international-phone` does not support the autocomplete event. ([Issue](https://github.com/ybrusentsov/react-international-phone/issues/230))