### PR TITLE
Add safe area view components

### DIFF
--- a/.changeset/odd-falcons-behave.md
+++ b/.changeset/odd-falcons-behave.md
@@ -1,0 +1,5 @@
+---
+"@worldcoin/mini-apps-ui-kit-react": minor
+---
+
+Add SafeAreaView component

--- a/.changeset/yellow-owls-punch.md
+++ b/.changeset/yellow-owls-punch.md
@@ -1,0 +1,5 @@
+---
+"@worldcoin/mini-apps-ui-kit-react": minor
+---
+
+Add useSafeAreaInsets hook

--- a/packages/mini-apps-ui-kit-react/package.json
+++ b/packages/mini-apps-ui-kit-react/package.json
@@ -258,6 +258,10 @@
       "types": "./dist/components/Haptic/index.d.ts",
       "default": "./dist/components/Haptic/index.js"
     },
+    "./SafeAreaView": {
+      "types": "./dist/components/SafeAreaView/index.d.ts",
+      "default": "./dist/components/SafeAreaView/index.js"
+    },
     "./tailwind": {
       "types": "./dist/tailwind/index.d.ts",
       "import": "./dist/tailwind/index.js",

--- a/packages/mini-apps-ui-kit-react/src/components/SafeAreaView/SafeAreaView.tsx
+++ b/packages/mini-apps-ui-kit-react/src/components/SafeAreaView/SafeAreaView.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+import { cn } from "../../lib/utils";
+import { useSafeAreaInsets } from "./useSafeAreaInsets";
+
+export type Edge = "top" | "right" | "bottom" | "left";
+
+export interface SafeAreaViewProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Edges to apply the safe area insets to. Defaults to all edges.
+   */
+  edges?: Edge[];
+  /**
+   * Additional class name for the container.
+   */
+  className?: string;
+  /**
+   * Children to render inside the SafeAreaView.
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * A component that applies safe area insets as padding to its children.
+ */
+const SafeAreaView = React.forwardRef<HTMLDivElement, SafeAreaViewProps>(
+  (
+    { edges = ["top", "right", "bottom", "left"], className, style, children, ...rest },
+    ref,
+  ) => {
+    const insets = useSafeAreaInsets();
+
+    const paddingStyle: React.CSSProperties = {
+      ...(edges.includes("top") && { paddingTop: insets.top }),
+      ...(edges.includes("right") && { paddingRight: insets.right }),
+      ...(edges.includes("bottom") && { paddingBottom: insets.bottom }),
+      ...(edges.includes("left") && { paddingLeft: insets.left }),
+      ...style,
+    };
+
+    return (
+      <div ref={ref} className={cn(className)} style={paddingStyle} {...rest}>
+        {children}
+      </div>
+    );
+  },
+);
+
+SafeAreaView.displayName = "SafeAreaView";
+
+export { SafeAreaView };

--- a/packages/mini-apps-ui-kit-react/src/components/SafeAreaView/index.ts
+++ b/packages/mini-apps-ui-kit-react/src/components/SafeAreaView/index.ts
@@ -1,0 +1,2 @@
+export { SafeAreaView } from "./SafeAreaView";
+export { useSafeAreaInsets } from "./useSafeAreaInsets";

--- a/packages/mini-apps-ui-kit-react/src/components/SafeAreaView/useSafeAreaInsets.ts
+++ b/packages/mini-apps-ui-kit-react/src/components/SafeAreaView/useSafeAreaInsets.ts
@@ -3,4 +3,4 @@ function useSafeAreaInsets() {
   return safeAreaInsets ?? { top: 0, right: 0, bottom: 0, left: 0 };
 }
 
-export default useSafeAreaInsets;
+export { useSafeAreaInsets };

--- a/packages/mini-apps-ui-kit-react/src/hooks/useSafeAreaInsets.ts
+++ b/packages/mini-apps-ui-kit-react/src/hooks/useSafeAreaInsets.ts
@@ -1,0 +1,6 @@
+function useSafeAreaInsets() {
+  const safeAreaInsets = window?.MiniKit?.deviceProperties?.safeAreaInsets;
+  return safeAreaInsets ?? { top: 0, right: 0, bottom: 0, left: 0 };
+}
+
+export default useSafeAreaInsets;

--- a/packages/mini-apps-ui-kit-react/src/index.ts
+++ b/packages/mini-apps-ui-kit-react/src/index.ts
@@ -54,6 +54,7 @@ export { Tabs, TabItem } from "./components/Tabs";
 export { LiveFeedback } from "./components/LiveFeedback";
 export { Skeleton, SkeletonTypography } from "./components/Skeleton";
 export { Haptic, useHaptics } from "./components/Haptic";
+export { SafeAreaView, useSafeAreaInsets } from "./components/SafeAreaView";
 
 // Export the Tailwind plugin
 export { default as uiKitTailwindPlugin } from "./tailwind";

--- a/packages/mini-apps-ui-kit-react/src/lib/haptics.ts
+++ b/packages/mini-apps-ui-kit-react/src/lib/haptics.ts
@@ -6,17 +6,6 @@ interface HapticFeedbackParams {
   style?: ImpactStyle | NotificationType;
 }
 
-// Type declaration for the global MiniKit object
-declare global {
-  interface Window {
-    MiniKit?: {
-      commands?: {
-        sendHapticFeedback?: (params: HapticFeedbackParams) => void;
-      };
-    };
-  }
-}
-
 const sendHapticFeedback = (params: HapticFeedbackParams) => {
   try {
     window.MiniKit?.commands?.sendHapticFeedback?.(params);
@@ -61,9 +50,9 @@ export function withHaptics<T extends (...args: any[]) => any>(
     try {
       hapticFn();
     } catch (error) {
-      console.warn('Haptic feedback failed:', error);
+      console.warn("Haptic feedback failed:", error);
     }
-    
+
     if (!fn) {
       return undefined as ReturnType<T>;
     }
@@ -73,7 +62,7 @@ export function withHaptics<T extends (...args: any[]) => any>(
     // Handle async functions
     if (result instanceof Promise) {
       return result.catch((error) => {
-        console.error('Function failed:', error);
+        console.error("Function failed:", error);
         throw error;
       }) as ReturnType<T>;
     }

--- a/packages/mini-apps-ui-kit-react/src/types/global.d.ts
+++ b/packages/mini-apps-ui-kit-react/src/types/global.d.ts
@@ -1,0 +1,32 @@
+type NotificationType = "success" | "warning" | "error";
+type ImpactStyle = "light" | "medium" | "heavy" | "soft" | "rigid";
+
+interface HapticFeedbackParams {
+  hapticsType: "impact" | "notification" | "selectionChanged";
+  style?: ImpactStyle | NotificationType;
+}
+
+interface MiniKit {
+  deviceProperties: {
+    safeAreaInsets: {
+      top: number;
+      right: number;
+      bottom: number;
+      left: number;
+    };
+    deviceOS: string;
+    worldAppVersion: number;
+  };
+  user: {
+    optedIntoOptionalAnalytics: boolean;
+  };
+  commands?: {
+    sendHapticFeedback?: (params: HapticFeedbackParams) => void;
+  };
+}
+
+declare global {
+  interface Window {
+    MiniKit?: MiniKit;
+  }
+}

--- a/packages/mini-apps-ui-kit-react/src/types/global.d.ts
+++ b/packages/mini-apps-ui-kit-react/src/types/global.d.ts
@@ -6,7 +6,7 @@ interface HapticFeedbackParams {
   style?: ImpactStyle | NotificationType;
 }
 
-interface MiniKit {
+export interface MiniKit {
   deviceProperties: {
     safeAreaInsets: {
       top: number;


### PR DESCRIPTION
- Introduced a new `SafeAreaView` component that applies safe area insets as padding to its children, enhancing layout adaptability across devices.
- Added `useSafeAreaInsets` hook for retrieving safe area insets from MiniKit device properties.
- Updated package.json to include the new component in exports.