### PR TITLE
Remove deprecated haptic options

### DIFF
--- a/packages/mini-apps-ui-kit-react/CHANGELOG.md
+++ b/packages/mini-apps-ui-kit-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @worldcoin/mini-apps-ui-kit-react
 
+## 1.3.1
+
+### Patch Changes
+
+- Remove deprecated Minikit haptic options. (`rigid` and `soft`)
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/mini-apps-ui-kit-react/package.json
+++ b/packages/mini-apps-ui-kit-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldcoin/mini-apps-ui-kit-react",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/mini-apps-ui-kit-react/src/lib/haptics.ts
+++ b/packages/mini-apps-ui-kit-react/src/lib/haptics.ts
@@ -1,5 +1,5 @@
 type NotificationType = "success" | "warning" | "error";
-type ImpactStyle = "light" | "medium" | "heavy" | "soft" | "rigid";
+type ImpactStyle = "light" | "medium" | "heavy";
 
 interface HapticFeedbackParams {
   hapticsType: "impact" | "notification" | "selectionChanged";

--- a/packages/mini-apps-ui-kit-react/src/types/global.d.ts
+++ b/packages/mini-apps-ui-kit-react/src/types/global.d.ts
@@ -1,5 +1,5 @@
 type NotificationType = "success" | "warning" | "error";
-type ImpactStyle = "light" | "medium" | "heavy" | "soft" | "rigid";
+type ImpactStyle = "light" | "medium" | "heavy";
 
 interface HapticFeedbackParams {
   hapticsType: "impact" | "notification" | "selectionChanged";

--- a/packages/mini-apps-ui-kit-react/stories/Haptic.stories.tsx
+++ b/packages/mini-apps-ui-kit-react/stories/Haptic.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof Haptic> = {
     },
     type: {
       control: "radio",
-      options: ["light", "medium", "heavy", "soft", "rigid", "success", "warning", "error"],
+      options: ["light", "medium", "heavy", "success", "warning", "error"],
       defaultValue: "light",
     },
     children: {


### PR DESCRIPTION
- Updated ImpactStyle type to exclude 'soft' and 'rigid' options.
- Adjusted Haptic story options to reflect the changes in ImpactStyle.


### Resources
[Minikit Haptic Implementation](https://github.com/search?q=repo:worldcoin/minikit-js%20impact&type=code)